### PR TITLE
Invalid workdir fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN mkdir -p /var/task
 # Register the Serverless and AWS bin directories
 ENV PATH="/root/.serverless/bin:/root/.local/bin:${PATH}"
 
-WORKDIR '/var/task​'
+WORKDIR '/var/task'


### PR DESCRIPTION
The workdir variable had a trailing (non-printable) unicode codepoint at the end which generated the folder (as displayed by `ls` of `task'$'\342\200\213` meaning that, when attaching code via a volume to `/var/task` you would not see the code (`ls /var/ | cat -A` shows `...
task$
taskM-bM-^@M-^K$` with the working directory/pwd being the latter one and the volume attached being the first one).

Took me a while to figure out why this wasn't working!